### PR TITLE
Add initial implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - run: cargo fmt --all -- --check
+
+      - run: cargo clippy --all-features -- -D warnings
+
+      - run: cargo check
+
+      - run: cargo check --no-default-features
+
+      - run: cargo check --no-default-features --features serde
+
+      - run: cargo check --no-default-features --features derive
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,8 +23,7 @@ dependencies = [
 [[package]]
 name = "serde"
 version = "1.0.204"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+source = "git+https://github.com/rushmorem/serde?branch=missing-visitor-methods#ffb9780e1127d63b983762d3c478f9817e1e9ba1"
 dependencies = [
  "serde_derive",
 ]
@@ -39,8 +38,7 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.204"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+source = "git+https://github.com/rushmorem/serde?branch=missing-visitor-methods#ffb9780e1127d63b983762d3c478f9817e1e9ba1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -49,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ version = "1.0.204"
 default-features = false
 features = ["alloc"]
 optional = true
+git = "https://github.com/rushmorem/serde"
+branch = "missing-visitor-methods"

--- a/src/de/enum.rs
+++ b/src/de/enum.rs
@@ -1,0 +1,309 @@
+use crate::de::identifier::Identifier;
+use crate::de::Map;
+use crate::de::Seq;
+use crate::Content;
+use crate::Data;
+use crate::Enum;
+use crate::Error;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt;
+use serde::de;
+use serde::de::MapAccess;
+use serde::de::SeqAccess;
+use serde::de::VariantAccess;
+use serde::Deserialize;
+
+pub(super) struct Deserializer<'de> {
+    enum_box: Box<Enum<'de>>,
+    human_readable: bool,
+}
+
+impl<'de> Deserializer<'de> {
+    pub(super) const fn new(enum_box: Box<Enum<'de>>, human_readable: bool) -> Self {
+        Self {
+            enum_box,
+            human_readable,
+        }
+    }
+}
+
+impl<'de> de::EnumAccess<'de> for Deserializer<'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let variant = Identifier::new(self.enum_box.variant, self.enum_box.variant_index as u64);
+        seed.deserialize(variant).map(|v| (v, self))
+    }
+}
+
+impl<'de> de::VariantAccess<'de> for Deserializer<'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        match self.enum_box.data {
+            Data::Unit => Ok(()),
+            _ => Err(self.enum_box.data.invalid_enum_type(&"unit variant")),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.enum_box.data {
+            Data::NewType { value } => {
+                let deserializer = crate::Deserializer::new(value, self.human_readable);
+                seed.deserialize(deserializer)
+            }
+            _ => Err(self.enum_box.data.invalid_enum_type(&"newtype variant")),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.enum_box.data {
+            Data::Tuple { values } => visitor.visit_seq(Seq::new(values, self.human_readable)),
+            _ => Err(self.enum_box.data.invalid_enum_type(&"tuple variant")),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.enum_box.data {
+            Data::Struct { fields } => visitor.visit_map(Map::from((fields, self.human_readable))),
+            _ => Err(self.enum_box.data.invalid_enum_type(&"struct variant")),
+        }
+    }
+}
+
+enum DataType {
+    Unit,
+    NewType,
+    Tuple,
+    Struct,
+}
+
+impl Data<'_> {
+    const fn typ(&self) -> DataType {
+        match self {
+            Data::Unit => DataType::Unit,
+            Data::NewType { .. } => DataType::NewType,
+            Data::Tuple { .. } => DataType::Tuple,
+            Data::Struct { .. } => DataType::Struct,
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Data::Unit => 0,
+            Data::NewType { .. } => 1,
+            Data::Tuple { values } => values.len(),
+            Data::Struct { fields } => fields.len(),
+        }
+    }
+
+    fn field_names(&self) -> Vec<&'static str> {
+        if let Data::Struct { fields } = self {
+            let mut vec = Vec::with_capacity(fields.len());
+            for (key, _) in fields {
+                vec.push(*key);
+            }
+            return vec;
+        }
+
+        Vec::new()
+    }
+}
+
+pub(super) fn visit_enum<'de, V>(
+    v: Box<Enum<'de>>,
+    human_readable: bool,
+    visitor: V,
+) -> Result<V::Value, Error>
+where
+    V: de::Visitor<'de>,
+{
+    let name = v.name;
+    let variant_index = v.variant_index;
+    let variant = v.variant;
+    let typ = v.data.typ();
+    let len = v.data.len();
+    let fields = v.data.field_names();
+    let data = Deserializer::new(v, human_readable);
+    match typ {
+        DataType::Unit => visitor.visit_unit_variant(name, variant_index, variant, data),
+        DataType::NewType => visitor.visit_newtype_variant(name, variant_index, variant, data),
+        DataType::Tuple => visitor.visit_tuple_variant(name, variant_index, variant, len, data),
+        DataType::Struct => {
+            visitor.visit_struct_variant(name, variant_index, variant, &fields, data)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Enum<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+pub(super) struct Visitor;
+
+impl<'de> de::Visitor<'de> for Visitor {
+    type Value = Enum<'de>;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        formatter.write_str("an enum")
+    }
+
+    fn visit_unit_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        let variant_access = data.variant::<Content>()?.1;
+        variant_access.unit_variant()?;
+        Ok(Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::Unit,
+        })
+    }
+
+    fn visit_newtype_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        let variant_access = data.variant::<Content>()?.1;
+        Ok(Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::NewType {
+                value: variant_access.newtype_variant()?,
+            },
+        })
+    }
+
+    fn visit_tuple_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        struct SeqVisitor;
+
+        impl<'de> de::Visitor<'de> for SeqVisitor {
+            type Value = Vec<Content<'de>>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Vec<Content>")
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let len = visitor.size_hint().unwrap_or_default();
+                let mut vec = Vec::with_capacity(len);
+                while let Some(content) = visitor.next_element()? {
+                    vec.push(content);
+                }
+                Ok(vec)
+            }
+        }
+
+        let variant_access = data.variant::<Content>()?.1;
+        Ok(Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::Tuple {
+                values: variant_access.tuple_variant(len, SeqVisitor)?,
+            },
+        })
+    }
+
+    fn visit_struct_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        fields: &[&'static str],
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        struct MapVisitor<'a>(&'a [&'static str]);
+
+        impl<'de> de::Visitor<'de> for MapVisitor<'_> {
+            type Value = Vec<(&'static str, Content<'de>)>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a map")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut vec = Vec::with_capacity(self.0.len());
+                while let Some(key) = map.next_key::<Cow<str>>()? {
+                    let value = map.next_value()?;
+                    for field_name in self.0 {
+                        if *field_name == key.as_ref() {
+                            vec.push((*field_name, value));
+                            break;
+                        }
+                    }
+                }
+                Ok(vec)
+            }
+        }
+
+        let variant_access = data.variant::<Content>()?.1;
+        let visitor = MapVisitor(fields);
+        Ok(Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::Struct {
+                fields: variant_access.struct_variant(&[], visitor)?,
+            },
+        })
+    }
+}

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -1,0 +1,88 @@
+use serde::de::{self, Expected, Unexpected};
+
+use crate::{Content, Data, Number};
+
+impl Content<'_> {
+    #[cold]
+    pub(super) fn invalid_type<E>(&self, exp: &dyn Expected) -> E
+    where
+        E: de::Error,
+    {
+        de::Error::invalid_type(self.unexpected(), exp)
+    }
+
+    #[cold]
+    fn unexpected(&self) -> Unexpected {
+        match self {
+            Content::Unit => Unexpected::Unit,
+            Content::Bool(v) => Unexpected::Bool(*v),
+            Content::Number(n) => match *n {
+                Number::I8(n) => Unexpected::Signed(n as i64),
+                Number::U8(n) => Unexpected::Unsigned(n as u64),
+                Number::I16(n) => Unexpected::Signed(n as i64),
+                Number::U16(n) => Unexpected::Unsigned(n as u64),
+                Number::I32(n) => Unexpected::Signed(n as i64),
+                Number::U32(n) => Unexpected::Unsigned(n as u64),
+                Number::F32(n) => Unexpected::Float(n as f64),
+                Number::I64(n) => Unexpected::Signed(n),
+                Number::U64(n) => Unexpected::Unsigned(n),
+                Number::F64(n) => Unexpected::Float(n),
+                Number::I128(n) => match i64::try_from(n) {
+                    Ok(n) => Unexpected::Signed(n),
+                    Err(_) => Unexpected::Other("128-bit signed integer"),
+                },
+                Number::U128(n) => match u64::try_from(n) {
+                    Ok(n) => Unexpected::Unsigned(n),
+                    Err(_) => Unexpected::Other("128-bit unsigned integer"),
+                },
+            },
+            Content::Char(v) => Unexpected::Char(*v),
+            Content::String(v) => Unexpected::Str(v.as_ref()),
+            Content::Bytes(v) => Unexpected::Bytes(v.as_ref()),
+            Content::Seq(_) => Unexpected::Seq,
+            Content::Map(_) => Unexpected::Map,
+            Content::Option(_) => Unexpected::Option,
+            Content::Struct(v) => v.data.unexpected_struct(),
+            Content::Enum(v) => v.data.unexpected_enum(),
+            Content::Tuple(_) => Unexpected::Other("tuple"),
+        }
+    }
+}
+
+impl Data<'_> {
+    #[cold]
+    pub(super) fn invalid_struct_type<E>(&self, exp: &dyn Expected) -> E
+    where
+        E: de::Error,
+    {
+        de::Error::invalid_type(self.unexpected_struct(), exp)
+    }
+
+    #[cold]
+    fn unexpected_struct(&self) -> Unexpected {
+        match self {
+            Data::Unit => Unexpected::Other("unit struct"),
+            Data::NewType { .. } => Unexpected::NewtypeStruct,
+            Data::Tuple { .. } => Unexpected::Other("tuple struct"),
+            Data::Struct { .. } => Unexpected::Other("struct"),
+        }
+    }
+
+    #[cold]
+    pub(super) fn invalid_enum_type<E>(&self, exp: &dyn Expected) -> E
+    where
+        E: de::Error,
+    {
+        de::Error::invalid_type(self.unexpected_enum(), exp)
+    }
+
+    #[cold]
+    fn unexpected_enum(&self) -> Unexpected {
+        match self {
+            Data::Unit => Unexpected::UnitVariant,
+            Data::NewType { .. } => Unexpected::NewtypeVariant,
+            Data::Tuple { .. } => Unexpected::TupleVariant,
+            Data::Struct { .. } => Unexpected::StructVariant,
+        }
+    }
+}

--- a/src/de/identifier.rs
+++ b/src/de/identifier.rs
@@ -1,0 +1,303 @@
+use crate::Error;
+use serde::de;
+use serde::de::Deserializer;
+use serde::de::Unexpected;
+use serde::de::Visitor;
+
+pub(super) struct Identifier {
+    name: &'static str,
+    index: u64,
+}
+
+impl Identifier {
+    pub(super) const fn new(name: &'static str, index: u64) -> Self {
+        Self { name, index }
+    }
+}
+
+impl<'de> Deserializer<'de> for Identifier {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.name)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(self.index)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.name)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_bytes(self.name.as_bytes())
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier bool"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier i8"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier i16"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier i32"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier i64"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier u8"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier u16"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier u32"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier f32"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier f64"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier char"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier unit struct"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier newtype struct"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier seq"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier tuple"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier tuple struct"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier map"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier struct"),
+            &visitor,
+        ))
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(
+            Unexpected::Other("identifier enum"),
+            &visitor,
+        ))
+    }
+}

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -1,0 +1,116 @@
+use crate::de::identifier::Identifier;
+use crate::Content;
+use crate::Deserializer;
+use crate::Error;
+use alloc::vec::IntoIter;
+use alloc::vec::Vec;
+use core::iter::Peekable;
+use core::mem;
+use serde::de;
+
+pub(super) enum Key<'de> {
+    Identifier(Identifier),
+    Content(Content<'de>),
+}
+
+pub(super) struct Map<'de> {
+    iter: Peekable<IntoIter<(Key<'de>, Content<'de>)>>,
+    human_readable: bool,
+}
+
+impl<'de> Map<'de> {
+    pub(super) fn new(vec: Vec<(Key<'de>, Content<'de>)>, human_readable: bool) -> Self {
+        Self {
+            human_readable,
+            iter: vec.into_iter().peekable(),
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for Map<'de> {
+    type Error = Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.peek_mut() {
+            Some((key, _)) => match mem::replace(key, Key::Content(Content::Unit)) {
+                Key::Content(content) => {
+                    let deserializer = Deserializer::new(content, self.human_readable);
+                    seed.deserialize(deserializer).map(Some)
+                }
+                Key::Identifier(identifier) => seed.deserialize(identifier).map(Some),
+            },
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((_, value)) => {
+                let deserializer = Deserializer::new(value, self.human_readable);
+                seed.deserialize(deserializer)
+            }
+            None => Err(de::Error::custom("[BUG] value is missing")),
+        }
+    }
+
+    fn next_entry_seed<K, V>(
+        &mut self,
+        kseed: K,
+        vseed: V,
+    ) -> Result<Option<(K::Value, V::Value)>, Self::Error>
+    where
+        K: de::DeserializeSeed<'de>,
+        V: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                let key = match key {
+                    Key::Identifier(identifier) => kseed.deserialize(identifier)?,
+                    Key::Content(content) => {
+                        let deserializer = Deserializer::new(content, self.human_readable);
+                        kseed.deserialize(deserializer)?
+                    }
+                };
+                let deserializer = Deserializer::new(value, self.human_readable);
+                let value = vseed.deserialize(deserializer)?;
+                Ok(Some((key, value)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> From<(Vec<(&'static str, Content<'de>)>, bool)> for Map<'de> {
+    fn from(fields: (Vec<(&'static str, Content<'de>)>, bool)) -> Self {
+        let mut vec = Vec::with_capacity(fields.0.len());
+        for (index, (key, value)) in fields.0.into_iter().enumerate() {
+            let key = Key::Identifier(Identifier::new(key, index as u64));
+            vec.push((key, value));
+        }
+        Self::new(vec, fields.1)
+    }
+}
+
+impl<'de> From<(Vec<(Content<'de>, Content<'de>)>, bool)> for Map<'de> {
+    fn from(fields: (Vec<(Content<'de>, Content<'de>)>, bool)) -> Self {
+        let mut vec = Vec::with_capacity(fields.0.len());
+        for (key, value) in fields.0 {
+            let key = Key::Content(key);
+            vec.push((key, value));
+        }
+        Self::new(vec, fields.1)
+    }
+}

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,0 +1,808 @@
+#![cfg(feature = "serde")]
+
+mod r#enum;
+mod identifier;
+mod map;
+mod number;
+mod seq;
+mod r#struct;
+mod tests;
+
+use crate::Content;
+use crate::Data;
+use crate::Error;
+use crate::Number;
+use alloc::borrow::Cow;
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+use identifier::Identifier;
+use map::Map;
+use seq::Seq;
+use serde::de;
+mod error;
+use map::Key;
+use serde::de::EnumAccess;
+use serde::de::MapAccess;
+use serde::de::SeqAccess;
+use serde::de::Visitor;
+
+const UNKNOWN_TYPE_NAME: &str = "<unknown>";
+
+/// Deserializes a value `T` from [`Content`]
+pub fn from_content<'de, T>(content: Content<'de>) -> Result<T, Error>
+where
+    T: de::Deserialize<'de>,
+{
+    let deserializer = Deserializer::new(content, false);
+    T::deserialize(deserializer)
+}
+
+/// A structure that deserializes Rust values into [Content].
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct Deserializer<'de> {
+    content: Content<'de>,
+    human_readable: bool,
+}
+
+impl<'de> Deserializer<'de> {
+    /// Creates a deserializer
+    pub const fn new(content: Content<'de>, human_readable: bool) -> Self {
+        Self {
+            content,
+            human_readable,
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for Deserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Unit => visitor.visit_unit(),
+            Content::Bool(v) => visitor.visit_bool(v),
+            Content::Number(n) => match n {
+                Number::I8(v) => visitor.visit_i8(v),
+                Number::U8(v) => visitor.visit_u8(v),
+                Number::I16(v) => visitor.visit_i16(v),
+                Number::U16(v) => visitor.visit_u16(v),
+                Number::I32(v) => visitor.visit_i32(v),
+                Number::U32(v) => visitor.visit_u32(v),
+                Number::F32(v) => visitor.visit_f32(v),
+                Number::I64(v) => visitor.visit_i64(v),
+                Number::U64(v) => visitor.visit_u64(v),
+                Number::F64(v) => visitor.visit_f64(v),
+                Number::I128(v) => visitor.visit_i128(v),
+                Number::U128(v) => visitor.visit_u128(v),
+            },
+            Content::Char(v) => visitor.visit_char(v),
+            Content::String(v) => match v {
+                Cow::Borrowed(v) => visitor.visit_borrowed_str(v),
+                Cow::Owned(v) => visitor.visit_string(v),
+            },
+            Content::Bytes(v) => match v {
+                Cow::Borrowed(v) => visitor.visit_borrowed_bytes(v),
+                Cow::Owned(v) => visitor.visit_byte_buf(v),
+            },
+            Content::Seq(v) => visitor.visit_seq(Seq::new(v, self.human_readable)),
+            Content::Map(v) => visitor.visit_map(Map::from((v, self.human_readable))),
+            Content::Option(v) => match v {
+                Some(v) => {
+                    let deserializer = Deserializer::new(*v, self.human_readable);
+                    visitor.visit_some(deserializer)
+                }
+                None => visitor.visit_none(),
+            },
+            Content::Struct(v) => match v.data {
+                Data::Unit => visitor.visit_unit_struct(v.name),
+                Data::NewType { value } => {
+                    let deserializer = Deserializer::new(value, self.human_readable);
+                    visitor.visit_newtype_struct_with_name(v.name, deserializer)
+                }
+                Data::Tuple { values } => {
+                    visitor.visit_tuple_struct(v.name, Seq::new(values, self.human_readable))
+                }
+                Data::Struct { fields } => {
+                    let len = fields.len();
+                    let mut field_names = Vec::with_capacity(len);
+                    let mut vec = Vec::with_capacity(len);
+                    for (index, (key, value)) in fields.into_iter().enumerate() {
+                        field_names.push(key);
+                        let key = Key::Identifier(Identifier::new(key, index as u64));
+                        vec.push((key, value));
+                    }
+                    let data = Map::new(vec, self.human_readable);
+                    visitor.visit_struct(v.name, &field_names, data)
+                }
+            },
+            Content::Enum(v) => r#enum::visit_enum(v, self.human_readable, visitor),
+            Content::Tuple(v) => visitor.visit_tuple(Seq::new(v, self.human_readable)),
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Bool(v) => visitor.visit_bool(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::I8(v)) => visitor.visit_i8(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::I16(v)) => visitor.visit_i16(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::I32(v)) => visitor.visit_i32(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::I64(v)) => visitor.visit_i64(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::I128(v)) => visitor.visit_i128(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::U8(v)) => visitor.visit_u8(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::U16(v)) => visitor.visit_u16(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::U32(v)) => visitor.visit_u32(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::U64(v)) => visitor.visit_u64(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::U128(v)) => visitor.visit_u128(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::F32(v)) => visitor.visit_f32(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Number(Number::F64(v)) => visitor.visit_f64(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Char(v) => visitor.visit_char(v),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::String(v) => match v {
+                Cow::Borrowed(v) => visitor.visit_borrowed_str(v),
+                Cow::Owned(v) => visitor.visit_string(v),
+            },
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Bytes(v) => match v {
+                Cow::Borrowed(v) => visitor.visit_borrowed_bytes(v),
+                Cow::Owned(v) => visitor.visit_byte_buf(v),
+            },
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Option(v) => match v {
+                Some(v) => {
+                    let deserializer = Deserializer::new(*v, self.human_readable);
+                    visitor.visit_some(deserializer)
+                }
+                None => visitor.visit_none(),
+            },
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Unit => visitor.visit_unit(),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Struct(v) => match v.data {
+                Data::Unit => visitor.visit_unit_struct(name),
+                data => Err(data.invalid_struct_type(&visitor)),
+            },
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Struct(v) => match v.data {
+                Data::NewType { value } => {
+                    let deserializer = Deserializer::new(value, self.human_readable);
+                    visitor.visit_newtype_struct_with_name(v.name, deserializer)
+                }
+                data => Err(data.invalid_struct_type(&visitor)),
+            },
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Seq(v) => visitor.visit_seq(Seq::new(v, self.human_readable)),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Tuple(v) => visitor.visit_tuple(Seq::new(v, self.human_readable)),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Struct(v) => match v.data {
+                Data::Tuple { values } => {
+                    visitor.visit_tuple_struct(name, Seq::new(values, self.human_readable))
+                }
+                data => Err(data.invalid_struct_type(&visitor)),
+            },
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Map(v) => visitor.visit_map(Map::from((v, self.human_readable))),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let field_names = fields;
+        match self.content {
+            Content::Struct(v) => match v.data {
+                Data::Struct { fields } => visitor.visit_struct(
+                    name,
+                    field_names,
+                    Map::from((fields, self.human_readable)),
+                ),
+                data => Err(data.invalid_struct_type(&visitor)),
+            },
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::Enum(v) => r#enum::visit_enum(v, self.human_readable, visitor),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.content {
+            Content::String(v) => match v {
+                Cow::Borrowed(v) => visitor.visit_borrowed_str(v),
+                Cow::Owned(v) => visitor.visit_string(v),
+            },
+            Content::Enum(v) => visitor.visit_borrowed_str(v.variant),
+            _ => Err(self.content.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.human_readable
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Content<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ContentVisitor)
+    }
+}
+
+struct ContentVisitor;
+
+impl<'de> Visitor<'de> for ContentVisitor {
+    type Value = Content<'de>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("any value")
+    }
+
+    fn visit_bool<F>(self, value: bool) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Bool(value))
+    }
+
+    fn visit_i8<F>(self, value: i8) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::I8(value)))
+    }
+
+    fn visit_i16<F>(self, value: i16) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::I16(value)))
+    }
+
+    fn visit_i32<F>(self, value: i32) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::I32(value)))
+    }
+
+    fn visit_i64<F>(self, value: i64) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::I64(value)))
+    }
+
+    fn visit_u8<F>(self, value: u8) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::U8(value)))
+    }
+
+    fn visit_u16<F>(self, value: u16) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::U16(value)))
+    }
+
+    fn visit_u32<F>(self, value: u32) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::U32(value)))
+    }
+
+    fn visit_u64<F>(self, value: u64) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::U64(value)))
+    }
+
+    fn visit_f32<F>(self, value: f32) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::F32(value)))
+    }
+
+    fn visit_f64<F>(self, value: f64) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Number(Number::F64(value)))
+    }
+
+    fn visit_char<F>(self, value: char) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Char(value))
+    }
+
+    fn visit_str<F>(self, value: &str) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::String(Cow::Owned(value.to_owned())))
+    }
+
+    fn visit_borrowed_str<F>(self, value: &'de str) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::String(Cow::Borrowed(value)))
+    }
+
+    fn visit_string<F>(self, value: String) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::String(Cow::Owned(value)))
+    }
+
+    fn visit_bytes<F>(self, value: &[u8]) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Bytes(Cow::Owned(value.to_owned())))
+    }
+
+    fn visit_borrowed_bytes<F>(self, value: &'de [u8]) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Bytes(Cow::Borrowed(value)))
+    }
+
+    fn visit_byte_buf<F>(self, value: Vec<u8>) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Bytes(Cow::Owned(value)))
+    }
+
+    fn visit_unit<F>(self) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Unit)
+    }
+
+    fn visit_none<F>(self) -> Result<Self::Value, F>
+    where
+        F: de::Error,
+    {
+        Ok(Content::Option(None))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        de::Deserialize::deserialize(deserializer).map(|v| Content::Option(Some(Box::new(v))))
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let data = r#struct::Visitor.visit_newtype_struct(deserializer)?;
+        Ok(Content::Struct(Box::new(data)))
+    }
+
+    fn visit_newtype_struct_with_name<D>(
+        self,
+        name: &'static str,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let data = r#struct::Visitor.visit_newtype_struct_with_name(name, deserializer)?;
+        Ok(Content::Struct(Box::new(data)))
+    }
+
+    fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        let len = visitor.size_hint().unwrap_or_default();
+        let mut vec = Vec::with_capacity(len);
+        while let Some(e) = visitor.next_element()? {
+            vec.push(e);
+        }
+        Ok(Content::Seq(vec))
+    }
+
+    fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        let len = visitor.size_hint().unwrap_or_default();
+        let mut vec = Vec::with_capacity(len);
+        while let Some(kv) = visitor.next_entry()? {
+            vec.push(kv);
+        }
+        Ok(Content::Map(vec))
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Content::Number(Number::I128(v)))
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Content::Number(Number::U128(v)))
+    }
+
+    fn visit_unit_struct<E>(self, name: &'static str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let data = r#struct::Visitor.visit_unit_struct(name)?;
+        Ok(Content::Struct(Box::new(data)))
+    }
+
+    fn visit_tuple<A>(self, mut visitor: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let len = visitor.size_hint().unwrap_or_default();
+        let mut vec = Vec::with_capacity(len);
+        while let Some(e) = visitor.next_element()? {
+            vec.push(e);
+        }
+        Ok(Content::Tuple(vec))
+    }
+
+    fn visit_tuple_struct<A>(self, name: &'static str, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let data = r#struct::Visitor.visit_tuple_struct(name, data)?;
+        Ok(Content::Struct(Box::new(data)))
+    }
+
+    fn visit_struct<A>(
+        self,
+        name: &'static str,
+        fields: &[&'static str],
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let data = r#struct::Visitor.visit_struct(name, fields, data)?;
+        Ok(Content::Struct(Box::new(data)))
+    }
+
+    fn visit_unit_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        let data = r#enum::Visitor.visit_unit_variant(name, variant_index, variant, data)?;
+        Ok(Content::Enum(Box::new(data)))
+    }
+
+    fn visit_newtype_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::EnumAccess<'de>,
+    {
+        let data = r#enum::Visitor.visit_newtype_variant(name, variant_index, variant, data)?;
+        Ok(Content::Enum(Box::new(data)))
+    }
+
+    fn visit_tuple_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        let data = r#enum::Visitor.visit_tuple_variant(name, variant_index, variant, len, data)?;
+        Ok(Content::Enum(Box::new(data)))
+    }
+
+    fn visit_struct_variant<A>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        fields: &[&'static str],
+        data: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        let data =
+            r#enum::Visitor.visit_struct_variant(name, variant_index, variant, fields, data)?;
+        Ok(Content::Enum(Box::new(data)))
+    }
+}

--- a/src/de/number.rs
+++ b/src/de/number.rs
@@ -1,0 +1,106 @@
+use crate::Number;
+use serde::de;
+use serde::Deserialize;
+
+impl<'de> Deserialize<'de> for Number {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+struct Visitor;
+
+impl<'de> de::Visitor<'de> for Visitor {
+    type Value = Number;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        formatter.write_str("a number")
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::I8(v))
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::I16(v))
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::I32(v))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::I64(v))
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::I128(v))
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::U8(v))
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::U16(v))
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::U32(v))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::U64(v))
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::U128(v))
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::F32(v))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Number::F64(v))
+    }
+}

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -1,0 +1,44 @@
+use crate::Content;
+use crate::Deserializer;
+use crate::Error;
+use alloc::vec::IntoIter;
+use alloc::vec::Vec;
+use serde::de;
+
+pub(super) struct Seq<'de> {
+    iter: IntoIter<Content<'de>>,
+    human_readable: bool,
+}
+
+impl<'de> Seq<'de> {
+    pub(super) fn new(vec: Vec<Content<'de>>, human_readable: bool) -> Self {
+        Self {
+            human_readable,
+            iter: vec.into_iter(),
+        }
+    }
+}
+
+impl<'de> de::SeqAccess<'de> for Seq<'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => {
+                let deserializer = Deserializer::new(value, self.human_readable);
+                seed.deserialize(deserializer).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}

--- a/src/de/struct.rs
+++ b/src/de/struct.rs
@@ -1,0 +1,110 @@
+use crate::de::UNKNOWN_TYPE_NAME;
+use crate::{Data, Struct};
+use alloc::{borrow::Cow, vec::Vec};
+use serde::{de, Deserialize};
+
+impl<'de> Deserialize<'de> for Struct<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+pub(super) struct Visitor;
+
+impl<'de> de::Visitor<'de> for Visitor {
+    type Value = Struct<'de>;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        formatter.write_str("a struct")
+    }
+
+    fn visit_unit_struct<E>(self, name: &'static str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Struct {
+            name,
+            data: Data::Unit,
+        })
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Ok(Struct {
+            name: UNKNOWN_TYPE_NAME,
+            data: Data::NewType {
+                value: Deserialize::deserialize(deserializer)?,
+            },
+        })
+    }
+
+    fn visit_newtype_struct_with_name<D>(
+        self,
+        name: &'static str,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Ok(Struct {
+            name,
+            data: Data::NewType {
+                value: Deserialize::deserialize(deserializer)?,
+            },
+        })
+    }
+
+    fn visit_tuple_struct<A>(
+        self,
+        name: &'static str,
+        mut visitor: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let len = visitor.size_hint().unwrap_or_default();
+        let mut values = Vec::with_capacity(len);
+        while let Some(e) = visitor.next_element()? {
+            values.push(e);
+        }
+        Ok(Struct {
+            name,
+            data: Data::Tuple { values },
+        })
+    }
+
+    fn visit_struct<A>(
+        self,
+        name: &'static str,
+        fields: &[&'static str],
+        mut visitor: A,
+    ) -> Result<Self::Value, A::Error>
+    where
+        A: de::MapAccess<'de>,
+    {
+        let len = fields.len();
+        let len = visitor
+            .size_hint()
+            .filter(|x| *x != 0)
+            .unwrap_or(len)
+            .min(len);
+        let mut vec = Vec::with_capacity(len);
+        while let Some(k) = visitor.next_key::<Cow<str>>()? {
+            let value = visitor.next_value()?;
+            for field in fields {
+                let key = *field;
+                if key == k {
+                    vec.push((key, value));
+                    break;
+                }
+            }
+        }
+        let data = Data::Struct { fields: vec };
+        Ok(Struct { name, data })
+    }
+}

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -1,0 +1,406 @@
+#![cfg(feature = "derive")]
+#![cfg(test)]
+
+use crate::from_content;
+use crate::Content;
+use crate::Data;
+use crate::Enum;
+use crate::Number;
+use crate::Struct;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+use serde::de::Visitor;
+use serde::Deserialize;
+use serde::Deserializer;
+
+#[test]
+fn deserialize_bool() {
+    assert_eq!(true, from_content(Content::Bool(true)).unwrap());
+    assert_eq!(false, from_content(Content::Bool(false)).unwrap());
+}
+
+#[test]
+fn deserialize_i8() {
+    assert_eq!(0i8, from_content(Content::Number(Number::I8(0))).unwrap());
+    assert_eq!(1i8, from_content(Content::Number(Number::I8(1))).unwrap());
+}
+
+#[test]
+fn deserialize_i16() {
+    assert_eq!(0i16, from_content(Content::Number(Number::I16(0))).unwrap());
+    assert_eq!(1i16, from_content(Content::Number(Number::I16(1))).unwrap());
+}
+
+#[test]
+fn deserialize_i32() {
+    assert_eq!(0i32, from_content(Content::Number(Number::I32(0))).unwrap());
+    assert_eq!(1i32, from_content(Content::Number(Number::I32(1))).unwrap());
+}
+
+#[test]
+fn deserialize_i64() {
+    assert_eq!(0i64, from_content(Content::Number(Number::I64(0))).unwrap());
+    assert_eq!(1i64, from_content(Content::Number(Number::I64(1))).unwrap());
+}
+
+#[test]
+fn deserialize_i128() {
+    assert_eq!(
+        0i128,
+        from_content(Content::Number(Number::I128(0))).unwrap()
+    );
+    assert_eq!(
+        1i128,
+        from_content(Content::Number(Number::I128(1))).unwrap()
+    );
+}
+
+#[test]
+fn deserialize_u8() {
+    assert_eq!(0u8, from_content(Content::Number(Number::U8(0))).unwrap());
+    assert_eq!(1u8, from_content(Content::Number(Number::U8(1))).unwrap());
+}
+
+#[test]
+fn deserialize_u16() {
+    assert_eq!(0u16, from_content(Content::Number(Number::U16(0))).unwrap());
+    assert_eq!(1u16, from_content(Content::Number(Number::U16(1))).unwrap());
+}
+
+#[test]
+fn deserialize_u32() {
+    assert_eq!(0u32, from_content(Content::Number(Number::U32(0))).unwrap());
+    assert_eq!(1u32, from_content(Content::Number(Number::U32(1))).unwrap());
+}
+
+#[test]
+fn deserialize_u64() {
+    assert_eq!(0u64, from_content(Content::Number(Number::U64(0))).unwrap());
+    assert_eq!(1u64, from_content(Content::Number(Number::U64(1))).unwrap());
+}
+
+#[test]
+fn deserialize_u128() {
+    assert_eq!(
+        0u128,
+        from_content(Content::Number(Number::U128(0))).unwrap()
+    );
+    assert_eq!(
+        1u128,
+        from_content(Content::Number(Number::U128(1))).unwrap()
+    );
+}
+
+#[test]
+fn deserialize_f32() {
+    assert_eq!(
+        0f32,
+        from_content(Content::Number(Number::F32(0.0))).unwrap()
+    );
+    assert_eq!(
+        1f32,
+        from_content(Content::Number(Number::F32(1.0))).unwrap()
+    );
+}
+
+#[test]
+fn deserialize_f64() {
+    assert_eq!(
+        0f64,
+        from_content(Content::Number(Number::F64(0.0))).unwrap()
+    );
+    assert_eq!(
+        1f64,
+        from_content(Content::Number(Number::F64(1.0))).unwrap()
+    );
+}
+
+#[test]
+fn deserialize_char() {
+    assert_eq!('a', from_content(Content::Char('a')).unwrap());
+}
+
+#[test]
+fn deserialize_string() {
+    let foo = String::from("foo");
+    assert_eq!(
+        foo,
+        from_content::<&str>(Content::String(Cow::Borrowed(&foo))).unwrap()
+    );
+    assert_eq!(
+        foo,
+        from_content::<String>(Content::String(Cow::Owned(foo.clone()))).unwrap()
+    );
+    assert_eq!(
+        String::new(),
+        from_content::<&str>(Content::String(Cow::Borrowed(""))).unwrap()
+    );
+    assert_eq!(
+        String::new(),
+        from_content::<String>(Content::String(Cow::Owned(String::new()))).unwrap()
+    );
+}
+
+#[test]
+fn deserialize_bytes() {
+    #[derive(Debug, PartialEq)]
+    struct Bytes(&'static [u8]);
+    impl Deserialize<'static> for Bytes {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'static>,
+        {
+            struct BytesVisitor;
+            impl Visitor<'static> for BytesVisitor {
+                type Value = Bytes;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("bytes")
+                }
+
+                fn visit_borrowed_bytes<E>(self, v: &'static [u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(Bytes(v))
+                }
+            }
+
+            deserializer.deserialize_bytes(BytesVisitor)
+        }
+    }
+    assert_eq!(
+        Bytes(b""),
+        from_content(Content::Bytes(Cow::Borrowed(b""))).unwrap(),
+    );
+    assert_eq!(
+        Bytes(b"foo"),
+        from_content(Content::Bytes(Cow::Borrowed(b"foo"))).unwrap(),
+    );
+}
+
+#[test]
+fn deserialize_option() {
+    assert_eq!(None::<&str>, from_content(Content::Option(None)).unwrap());
+    assert_eq!(
+        Some('a'),
+        from_content(Content::Option(Some(Box::new(Content::Char('a'))))).unwrap()
+    );
+    assert_eq!(Some(()), from_content(Content::Unit).unwrap());
+    assert_eq!(Some(true), from_content(Content::Bool(true)).unwrap());
+}
+
+#[test]
+fn deserialize_unit() {
+    assert_eq!((), from_content(Content::Unit).unwrap());
+    assert_eq!(
+        Some(()),
+        from_content(Content::Option(Some(Box::new(Content::Unit)))).unwrap(),
+    );
+}
+
+#[test]
+fn deserialize_unit_struct() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Foo;
+    assert_eq!(
+        Foo,
+        from_content(Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::Unit
+        })))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_unit_variant() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Foo {
+        Bar,
+    }
+    assert_eq!(
+        Foo::Bar,
+        from_content(Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 0,
+            variant: "Bar",
+            data: Data::Unit
+        })))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_newtype_struct() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Foo(bool);
+    assert_eq!(
+        Foo(true),
+        from_content(Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::NewType {
+                value: Content::Bool(true)
+            }
+        })))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_newtype_variant() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Foo {
+        Bar(bool),
+    }
+    assert_eq!(
+        Foo::Bar(true),
+        from_content(Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 0,
+            variant: "Bar",
+            data: Data::NewType {
+                value: Content::Bool(true)
+            }
+        })))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_seq() {
+    assert_eq!(
+        Vec::<bool>::new(),
+        from_content::<Vec<_>>(Content::Seq(Vec::new())).unwrap()
+    );
+    assert_eq!(
+        vec![true, false],
+        from_content::<Vec<_>>(Content::Seq(vec![
+            Content::Bool(true),
+            Content::Bool(false)
+        ]))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_tuple() {
+    assert_eq!(
+        (true,),
+        from_content(Content::Tuple(vec![Content::Bool(true)])).unwrap()
+    );
+    assert_eq!(
+        (true, 'a', "foo"),
+        from_content(Content::Tuple(vec![
+            Content::Bool(true),
+            Content::Char('a'),
+            Content::String(Cow::Borrowed("foo"))
+        ]))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_tuple_struct() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Foo(bool, char);
+    assert_eq!(
+        Foo(true, 'a'),
+        from_content(Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::Tuple {
+                values: vec![Content::Bool(true), Content::Char('a')],
+            }
+        })))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_tuple_variant() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Foo {
+        Bar(bool, char),
+    }
+    assert_eq!(
+        Foo::Bar(true, 'a'),
+        from_content(Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 0,
+            variant: "Bar",
+            data: Data::Tuple {
+                values: vec![Content::Bool(true), Content::Char('a')],
+            }
+        })))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_map() {
+    assert_eq!(
+        BTreeMap::<(), ()>::new(),
+        from_content(Content::Map(Vec::new())).unwrap()
+    );
+    let mut map = BTreeMap::new();
+    map.insert('f', false);
+    map.insert('t', true);
+    assert_eq!(
+        map,
+        from_content(Content::Map(vec![
+            (Content::Char('f'), Content::Bool(false)),
+            (Content::Char('t'), Content::Bool(true)),
+        ]))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_struct() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Foo {
+        bar: bool,
+        baz: char,
+    }
+    assert_eq!(
+        Foo {
+            bar: true,
+            baz: 'a'
+        },
+        from_content(Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::Struct {
+                fields: vec![("bar", Content::Bool(true)), ("baz", Content::Char('a'))],
+            }
+        })))
+        .unwrap()
+    );
+}
+
+#[test]
+fn deserialize_struct_variant() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Foo {
+        Bar { bar: bool, baz: char },
+    }
+    assert_eq!(
+        Foo::Bar {
+            bar: true,
+            baz: 'a',
+        },
+        from_content(Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 0,
+            variant: "Bar",
+            data: Data::Struct {
+                fields: vec![("bar", Content::Bool(true)), ("baz", Content::Char('a'))],
+            }
+        })))
+        .unwrap()
+    );
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,44 @@
+use alloc::string::String;
+#[cfg(feature = "serde")]
+use alloc::string::ToString;
+use core::fmt;
+
+/// Alias for [core::result::Result] with [crate::Error] as the error type.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// The error type returned by this crate.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "derive", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive] // In case we add new error variants in future.
+pub enum Error {
+    /// A custom error message from `serde`.
+    Custom(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Custom(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::ser::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: fmt::Display,
+    {
+        Self::Custom(msg.to_string())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::de::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: fmt::Display,
+    {
+        Self::Custom(msg.to_string())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,197 @@
+//! A container for the Serde data model.
 
+#![no_std]
+#![forbid(unsafe_code)]
+#![cfg_attr(test, deny(warnings))]
+#![deny(missing_docs, unused_imports)]
+
+extern crate alloc;
+
+mod de;
+mod error;
+mod ser;
+mod tests;
+
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+pub use error::Error;
+pub use error::Result;
+#[cfg(feature = "serde")]
+pub use {de::from_content, de::Deserializer, ser::to_content, ser::Serializer};
+
+/// A containter for all Rust number types.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[non_exhaustive] // In case Rust introduces new number types.
+pub enum Number {
+    /// Holds an 8-bit signed integer type.
+    I8(i8),
+    /// Holds an 8-bit unsigned integer type.
+    U8(u8),
+
+    /// Holds a 16-bit signed integer type.
+    I16(i16),
+    /// Holds a 16-bit unsigned integer type.
+    U16(u16),
+
+    /// Holds a 32-bit signed integer type.
+    I32(i32),
+    /// Holds a 32-bit unsigned integer type.
+    U32(u32),
+    /// Holds a 32-bit floating point type.
+    F32(f32),
+
+    /// Holds a 64-bit signed integer type.
+    I64(i64),
+    /// Holds a 64-bit unsigned integer type.
+    U64(u64),
+    /// Holds a 32-bit floating point type.
+    F64(f64),
+
+    /// Holds a 128-bit signed integer type.
+    I128(i128),
+    /// Holds a 128-bit unsigned integer type.
+    U128(u128),
+}
+
+/// Represents struct and enum data.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub enum Data<'a> {
+    /// Represents unit structs and unit enum variants.
+    Unit,
+    /// Represents newtype structs and enum variants.
+    NewType {
+        /// The value of the newtype struct or enum variant.
+        value: Content<'a>,
+    },
+    /// Represents tuple structs and enum variants.
+    Tuple {
+        /// The values of the tuple struct or enum variant.
+        values: Vec<Content<'a>>,
+    },
+    /// Represents object-like structs and enum variants.
+    Struct {
+        /// A vector of field names and their values.
+        fields: Vec<(&'static str, Content<'a>)>,
+    },
+}
+
+impl Data<'_> {
+    /// Moves data where possible or otherwise clones it into an owned object.
+    pub fn into_owned(self) -> Data<'static> {
+        match self {
+            Data::Unit => Data::Unit,
+            Data::NewType { value } => Data::NewType {
+                value: value.into_owned(),
+            },
+            Data::Tuple { values } => Data::Tuple {
+                values: values.into_iter().map(Content::into_owned).collect(),
+            },
+            Data::Struct { fields } => Data::Struct {
+                fields: fields
+                    .into_iter()
+                    .map(|(key, value)| (key, value.into_owned()))
+                    .collect(),
+            },
+        }
+    }
+}
+
+/// Represents a Rust struct.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct Struct<'a> {
+    /// The name of the struct.
+    pub name: &'static str,
+    /// The data of the struct.
+    pub data: Data<'a>,
+}
+
+impl Struct<'_> {
+    /// Moves data where possible or otherwise clones it into an owned object.
+    pub fn into_owned(self) -> Struct<'static> {
+        Struct {
+            data: self.data.into_owned(),
+            ..self
+        }
+    }
+}
+
+/// Represents a Rust enum.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct Enum<'a> {
+    /// The name of the enum.
+    pub name: &'static str,
+    /// The index of the enum variant.
+    pub variant_index: u32,
+    /// The name of the enum variant.
+    pub variant: &'static str,
+    /// The data of the enum.
+    pub data: Data<'a>,
+}
+
+impl Enum<'_> {
+    /// Moves data where possible or otherwise clones it into an owned object.
+    pub fn into_owned(self) -> Enum<'static> {
+        Enum {
+            data: self.data.into_owned(),
+            ..self
+        }
+    }
+}
+
+/// Represents any valid Rust value.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub enum Content<'a> {
+    /// Represents the Rust unit type, `()`.
+    Unit,
+    /// Represents a Rust boolean.
+    Bool(bool),
+    /// Represents any Rust number.
+    Number(Number),
+    /// Represents a Rust character.
+    Char(char),
+    /// Represents a Rust string.
+    String(Cow<'a, str>),
+    /// Represents a Rust byte array.
+    Bytes(Cow<'a, [u8]>),
+    /// Represents an array of Rust values.
+    Seq(Vec<Content<'a>>),
+    /// Represents a map of Rust values.
+    Map(Vec<(Content<'a>, Content<'a>)>),
+    /// Represents optional Rust values.
+    Option(Option<Box<Content<'a>>>),
+    /// Represents a Rust struct.
+    Struct(Box<Struct<'a>>),
+    /// Represents a Rust enum.
+    Enum(Box<Enum<'a>>),
+    /// Represents a Rust tuple.
+    Tuple(Vec<Content<'a>>),
+}
+
+impl Content<'_> {
+    /// Moves data where possible or otherwise clones it into an owned object.
+    pub fn into_owned(self) -> Content<'static> {
+        match self {
+            Content::Unit => Content::Unit,
+            Content::Bool(v) => Content::Bool(v),
+            Content::Number(v) => Content::Number(v),
+            Content::Char(v) => Content::Char(v),
+            Content::String(v) => Content::String(Cow::Owned(v.into_owned())),
+            Content::Bytes(v) => Content::Bytes(Cow::Owned(v.into_owned())),
+            Content::Seq(v) => Content::Seq(v.into_iter().map(Self::into_owned).collect()),
+            Content::Map(v) => Content::Map(
+                v.into_iter()
+                    .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                    .collect(),
+            ),
+            Content::Option(v) => match v {
+                Some(v) => Content::Option(Some(Box::new(v.into_owned()))),
+                None => Content::Option(None),
+            },
+            Content::Struct(v) => Content::Struct(Box::new(v.into_owned())),
+            Content::Enum(v) => Content::Enum(Box::new(v.into_owned())),
+            Content::Tuple(v) => Content::Tuple(v.into_iter().map(Self::into_owned).collect()),
+        }
+    }
+}

--- a/src/ser/enum.rs
+++ b/src/ser/enum.rs
@@ -1,0 +1,105 @@
+use crate::ser::Content;
+use crate::Data;
+use crate::Error;
+use crate::Serializer;
+use alloc::boxed::Box;
+use serde::ser;
+use serde::ser::SerializeStructVariant;
+use serde::ser::SerializeTupleVariant;
+
+pub struct Enum {
+    r#enum: crate::Enum<'static>,
+    human_readable: bool,
+}
+
+impl Enum {
+    pub(super) const fn new(r#enum: crate::Enum<'static>, human_readable: bool) -> Self {
+        Self {
+            r#enum,
+            human_readable,
+        }
+    }
+}
+
+impl ser::Serialize for crate::Enum<'static> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match &self.data {
+            Data::Unit => {
+                serializer.serialize_unit_variant(self.name, self.variant_index, self.variant)
+            }
+            Data::NewType { value } => serializer.serialize_newtype_variant(
+                self.name,
+                self.variant_index,
+                self.variant,
+                value,
+            ),
+            Data::Tuple { values } => {
+                let mut tup = serializer.serialize_tuple_variant(
+                    self.name,
+                    self.variant_index,
+                    self.variant,
+                    values.len(),
+                )?;
+                for value in values {
+                    tup.serialize_field(value)?;
+                }
+                tup.end()
+            }
+            Data::Struct { fields } => {
+                let mut map = serializer.serialize_struct_variant(
+                    self.name,
+                    self.variant_index,
+                    self.variant,
+                    fields.len(),
+                )?;
+                for (key, value) in fields {
+                    map.serialize_field(key, value)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl ser::SerializeStructVariant for Enum {
+    type Ok = Content;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        if let Data::Struct { fields } = &mut self.r#enum.data {
+            let value = value.serialize(Serializer::new(self.human_readable))?;
+            fields.push((key, value));
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Enum(Box::new(self.r#enum)))
+    }
+}
+
+impl ser::SerializeTupleVariant for Enum {
+    type Ok = Content;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        if let Data::Tuple { values } = &mut self.r#enum.data {
+            let value = value.serialize(Serializer::new(self.human_readable))?;
+            values.push(value);
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Enum(Box::new(self.r#enum)))
+    }
+}

--- a/src/ser/map.rs
+++ b/src/ser/map.rs
@@ -1,0 +1,59 @@
+use crate::ser::Content;
+use crate::Error;
+use crate::Serializer;
+use alloc::vec::Vec;
+use serde::ser;
+
+pub struct Map {
+    vec: Vec<(Content, Content)>,
+    human_readable: bool,
+}
+
+impl Map {
+    pub(super) const fn new(vec: Vec<(Content, Content)>, human_readable: bool) -> Self {
+        Self {
+            vec,
+            human_readable,
+        }
+    }
+}
+
+impl ser::SerializeMap for Map {
+    type Ok = Content;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let key = key.serialize(Serializer::new(self.human_readable))?;
+        self.vec.push((key, Content::Unit));
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        if let Some(last) = self.vec.last_mut() {
+            last.1 = value.serialize(Serializer::new(self.human_readable))?;
+        }
+        Ok(())
+    }
+
+    fn serialize_entry<K, V>(&mut self, key: &K, value: &V) -> Result<(), Self::Error>
+    where
+        K: ?Sized + ser::Serialize,
+        V: ?Sized + ser::Serialize,
+    {
+        let serializer = Serializer::new(self.human_readable);
+        let key = key.serialize(serializer)?;
+        let value = value.serialize(serializer)?;
+        self.vec.push((key, value));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Map(self.vec))
+    }
+}

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,0 +1,333 @@
+#![cfg(feature = "serde")]
+
+mod r#enum;
+mod map;
+mod number;
+mod seq;
+mod r#struct;
+mod tests;
+mod tuple;
+
+use crate::Data;
+use crate::Error;
+use crate::Number;
+use alloc::borrow::Cow;
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::fmt;
+use map::Map;
+use r#enum::Enum;
+use r#struct::Struct;
+use seq::Seq;
+use serde::ser;
+use serde::ser::SerializeMap;
+use serde::ser::SerializeSeq;
+use serde::ser::SerializeTuple;
+use tuple::Tuple;
+
+type Content = super::Content<'static>;
+
+/// Convert a `T` into `Content` which is an enum that can represent any valid Rust data.
+pub fn to_content<T>(value: T) -> Result<Content, Error>
+where
+    T: ser::Serialize,
+{
+    value.serialize(Serializer::new(false))
+}
+
+/// A structure for serialising Rust values into [crate::Content].
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Serializer {
+    human_readable: bool,
+}
+
+impl Serializer {
+    /// Creates a serializer
+    pub const fn new(human_readable: bool) -> Self {
+        Self { human_readable }
+    }
+}
+
+impl ser::Serializer for Serializer {
+    type Ok = Content;
+    type Error = Error;
+
+    type SerializeSeq = Seq;
+    type SerializeTuple = Tuple;
+    type SerializeTupleStruct = Struct;
+    type SerializeTupleVariant = Enum;
+    type SerializeMap = Map;
+    type SerializeStruct = Struct;
+    type SerializeStructVariant = Enum;
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Error> {
+        Ok(Content::Bool(value))
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::I8(value)))
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::I16(value)))
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::I32(value)))
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::I64(value)))
+    }
+
+    fn serialize_i128(self, value: i128) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::I128(value)))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::U8(value)))
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::U16(value)))
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::U32(value)))
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::U64(value)))
+    }
+
+    fn serialize_u128(self, value: u128) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::U128(value)))
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::F32(value)))
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok, Error> {
+        Ok(Content::Number(Number::F64(value)))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Error> {
+        Ok(Content::Char(value))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Error> {
+        Ok(Content::String(Cow::Owned(value.to_owned())))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Error> {
+        Ok(Content::Bytes(Cow::Owned(value.to_owned())))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Unit)
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Error> {
+        Ok(Content::Struct(Box::new(super::Struct {
+            name,
+            data: Data::Unit,
+        })))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Error> {
+        Ok(Content::Enum(Box::new(super::Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::Unit,
+        })))
+    }
+
+    fn serialize_newtype_struct<T>(self, name: &'static str, value: &T) -> Result<Self::Ok, Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        Ok(Content::Struct(Box::new(super::Struct {
+            name,
+            data: Data::NewType {
+                value: value.serialize(self)?,
+            },
+        })))
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        Ok(Content::Enum(Box::new(super::Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::NewType {
+                value: value.serialize(self)?,
+            },
+        })))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Option(None))
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let content = value.serialize(self)?;
+        Ok(Content::Option(Some(Box::new(content))))
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+        Ok(Seq::new(
+            Vec::with_capacity(len.unwrap_or_default()),
+            self.human_readable,
+        ))
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Error> {
+        Ok(Tuple::new(Vec::with_capacity(len), self.human_readable))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Error> {
+        let st = super::Struct {
+            name,
+            data: Data::Tuple {
+                values: Vec::with_capacity(len),
+            },
+        };
+        Ok(Struct::new(st, self.human_readable))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Error> {
+        let en = super::Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::Tuple {
+                values: Vec::with_capacity(len),
+            },
+        };
+        Ok(Enum::new(en, self.human_readable))
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Error> {
+        Ok(Map::new(
+            Vec::with_capacity(len.unwrap_or_default()),
+            self.human_readable,
+        ))
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Error> {
+        let st = super::Struct {
+            name,
+            data: Data::Struct {
+                fields: Vec::with_capacity(len),
+            },
+        };
+        Ok(Struct::new(st, self.human_readable))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Error> {
+        let en = super::Enum {
+            name,
+            variant_index,
+            variant,
+            data: Data::Struct {
+                fields: Vec::with_capacity(len),
+            },
+        };
+        Ok(Enum::new(en, self.human_readable))
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + fmt::Display,
+    {
+        Ok(Content::String(Cow::Owned(value.to_string())))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.human_readable
+    }
+}
+
+impl ser::Serialize for Content {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match self {
+            Content::Unit => serializer.serialize_unit(),
+            Content::Bool(v) => serializer.serialize_bool(*v),
+            Content::Number(v) => v.serialize(serializer),
+            Content::Char(v) => serializer.serialize_char(*v),
+            Content::String(v) => serializer.serialize_str(v.as_ref()),
+            Content::Bytes(v) => serializer.serialize_bytes(v.as_ref()),
+            Content::Seq(v) => {
+                let mut seq = serializer.serialize_seq(Some(v.len()))?;
+                for value in v {
+                    seq.serialize_element(value)?;
+                }
+                seq.end()
+            }
+            Content::Map(v) => {
+                let mut map = serializer.serialize_map(Some(v.len()))?;
+                for (key, value) in v {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+            Content::Option(v) => match v {
+                Some(v) => serializer.serialize_some(v),
+                None => serializer.serialize_none(),
+            },
+            Content::Struct(v) => v.serialize(serializer),
+            Content::Enum(v) => v.serialize(serializer),
+            Content::Tuple(v) => {
+                let mut tup = serializer.serialize_tuple(v.len())?;
+                for value in v {
+                    tup.serialize_element(value)?;
+                }
+                tup.end()
+            }
+        }
+    }
+}

--- a/src/ser/number.rs
+++ b/src/ser/number.rs
@@ -1,0 +1,24 @@
+use crate::Number;
+use serde::ser;
+
+impl ser::Serialize for Number {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match *self {
+            Number::I8(v) => serializer.serialize_i8(v),
+            Number::U8(v) => serializer.serialize_u8(v),
+            Number::I16(v) => serializer.serialize_i16(v),
+            Number::U16(v) => serializer.serialize_u16(v),
+            Number::I32(v) => serializer.serialize_i32(v),
+            Number::U32(v) => serializer.serialize_u32(v),
+            Number::F32(v) => serializer.serialize_f32(v),
+            Number::I64(v) => serializer.serialize_i64(v),
+            Number::U64(v) => serializer.serialize_u64(v),
+            Number::F64(v) => serializer.serialize_f64(v),
+            Number::I128(v) => serializer.serialize_i128(v),
+            Number::U128(v) => serializer.serialize_u128(v),
+        }
+    }
+}

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -1,0 +1,37 @@
+use crate::ser::Content;
+use crate::Error;
+use crate::Serializer;
+use alloc::vec::Vec;
+use serde::ser;
+
+pub struct Seq {
+    vec: Vec<Content>,
+    human_readable: bool,
+}
+
+impl Seq {
+    pub(super) const fn new(vec: Vec<Content>, human_readable: bool) -> Self {
+        Self {
+            vec,
+            human_readable,
+        }
+    }
+}
+
+impl ser::SerializeSeq for Seq {
+    type Ok = Content;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let value = value.serialize(Serializer::new(self.human_readable))?;
+        self.vec.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Seq(self.vec))
+    }
+}

--- a/src/ser/struct.rs
+++ b/src/ser/struct.rs
@@ -1,0 +1,88 @@
+use crate::ser::Content;
+use crate::Data;
+use crate::Error;
+use crate::Serializer;
+use alloc::boxed::Box;
+use serde::ser;
+use serde::ser::SerializeStruct;
+use serde::ser::SerializeTupleStruct;
+
+pub struct Struct {
+    r#struct: crate::Struct<'static>,
+    human_readable: bool,
+}
+
+impl Struct {
+    pub(super) const fn new(r#struct: crate::Struct<'static>, human_readable: bool) -> Self {
+        Self {
+            r#struct,
+            human_readable,
+        }
+    }
+}
+
+impl ser::Serialize for crate::Struct<'static> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match &self.data {
+            Data::Unit => serializer.serialize_unit_struct(self.name),
+            Data::NewType { value } => serializer.serialize_newtype_struct(self.name, value),
+            Data::Tuple { values } => {
+                let mut tup = serializer.serialize_tuple_struct(self.name, values.len())?;
+                for value in values {
+                    tup.serialize_field(value)?;
+                }
+                tup.end()
+            }
+            Data::Struct { fields } => {
+                let mut map = serializer.serialize_struct(self.name, fields.len())?;
+                for (key, value) in fields {
+                    map.serialize_field(key, value)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl ser::SerializeStruct for Struct {
+    type Ok = Content;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        if let Data::Struct { fields } = &mut self.r#struct.data {
+            let value = value.serialize(Serializer::new(self.human_readable))?;
+            fields.push((key, value));
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Struct(Box::new(self.r#struct)))
+    }
+}
+
+impl ser::SerializeTupleStruct for Struct {
+    type Ok = Content;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        if let Data::Tuple { values } = &mut self.r#struct.data {
+            let value = value.serialize(Serializer::new(self.human_readable))?;
+            values.push(value);
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Struct(Box::new(self.r#struct)))
+    }
+}

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -1,0 +1,350 @@
+#![cfg(feature = "derive")]
+#![cfg(test)]
+
+use crate::to_content;
+use crate::Content;
+use crate::Data;
+use crate::Enum;
+use crate::Number;
+use crate::Struct;
+use alloc::borrow::Cow;
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use serde::Serialize;
+
+#[test]
+fn serialize_bool() {
+    assert_eq!(to_content(true).unwrap(), Content::Bool(true));
+    assert_eq!(to_content(false).unwrap(), Content::Bool(false));
+}
+
+#[test]
+fn serialize_i8() {
+    assert_eq!(to_content(0i8).unwrap(), Content::Number(Number::I8(0)));
+    assert_eq!(to_content(1i8).unwrap(), Content::Number(Number::I8(1)));
+}
+
+#[test]
+fn serialize_i16() {
+    assert_eq!(to_content(0i16).unwrap(), Content::Number(Number::I16(0)));
+    assert_eq!(to_content(1i16).unwrap(), Content::Number(Number::I16(1)));
+}
+
+#[test]
+fn serialize_i32() {
+    assert_eq!(to_content(0i32).unwrap(), Content::Number(Number::I32(0)));
+    assert_eq!(to_content(1i32).unwrap(), Content::Number(Number::I32(1)));
+}
+
+#[test]
+fn serialize_i64() {
+    assert_eq!(to_content(0i64).unwrap(), Content::Number(Number::I64(0)));
+    assert_eq!(to_content(1i64).unwrap(), Content::Number(Number::I64(1)));
+}
+
+#[test]
+fn serialize_i128() {
+    assert_eq!(to_content(0i128).unwrap(), Content::Number(Number::I128(0)));
+    assert_eq!(to_content(1i128).unwrap(), Content::Number(Number::I128(1)));
+}
+
+#[test]
+fn serialize_u8() {
+    assert_eq!(to_content(0u8).unwrap(), Content::Number(Number::U8(0)));
+    assert_eq!(to_content(1u8).unwrap(), Content::Number(Number::U8(1)));
+}
+
+#[test]
+fn serialize_u16() {
+    assert_eq!(to_content(0u16).unwrap(), Content::Number(Number::U16(0)));
+    assert_eq!(to_content(1u16).unwrap(), Content::Number(Number::U16(1)));
+}
+
+#[test]
+fn serialize_u32() {
+    assert_eq!(to_content(0u32).unwrap(), Content::Number(Number::U32(0)));
+    assert_eq!(to_content(1u32).unwrap(), Content::Number(Number::U32(1)));
+}
+
+#[test]
+fn serialize_u64() {
+    assert_eq!(to_content(0u64).unwrap(), Content::Number(Number::U64(0)));
+    assert_eq!(to_content(1u64).unwrap(), Content::Number(Number::U64(1)));
+}
+
+#[test]
+fn serialize_u128() {
+    assert_eq!(to_content(0u128).unwrap(), Content::Number(Number::U128(0)));
+    assert_eq!(to_content(1u128).unwrap(), Content::Number(Number::U128(1)));
+}
+
+#[test]
+fn serialize_f32() {
+    assert_eq!(to_content(0f32).unwrap(), Content::Number(Number::F32(0.0)));
+    assert_eq!(to_content(1f32).unwrap(), Content::Number(Number::F32(1.0)));
+}
+
+#[test]
+fn serialize_f64() {
+    assert_eq!(to_content(0f64).unwrap(), Content::Number(Number::F64(0.0)));
+    assert_eq!(to_content(1f64).unwrap(), Content::Number(Number::F64(1.0)));
+}
+
+#[test]
+fn serialize_char() {
+    assert_eq!(to_content('a').unwrap(), Content::Char('a'));
+}
+
+#[test]
+fn serialize_string() {
+    assert_eq!(
+        to_content("foo").unwrap(),
+        Content::String(Cow::Borrowed("foo"))
+    );
+    assert_eq!(
+        to_content("foo").unwrap(),
+        Content::String(Cow::Owned("foo".to_owned()))
+    );
+    assert_eq!(
+        to_content(String::new()).unwrap(),
+        Content::String(Cow::Borrowed(""))
+    );
+    assert_eq!(
+        to_content(String::new()).unwrap(),
+        Content::String(Cow::Owned(String::new()))
+    );
+}
+
+#[test]
+fn serialize_bytes() {
+    struct Bytes(&'static [u8]);
+    impl Serialize for Bytes {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            serializer.serialize_bytes(self.0)
+        }
+    }
+    assert_eq!(
+        to_content(Bytes(b"")).unwrap(),
+        Content::Bytes(Cow::Borrowed(b""))
+    );
+    assert_eq!(
+        to_content(Bytes(b"foo")).unwrap(),
+        Content::Bytes(Cow::Borrowed(b"foo"))
+    );
+}
+
+#[test]
+fn serialize_option() {
+    assert_eq!(to_content(None::<&str>).unwrap(), Content::Option(None));
+    assert_eq!(
+        to_content(Some('a')).unwrap(),
+        Content::Option(Some(Box::new(Content::Char('a'))))
+    );
+}
+
+#[test]
+fn serialize_unit() {
+    assert_eq!(to_content(()).unwrap(), Content::Unit);
+    assert_eq!(
+        to_content(Some(())).unwrap(),
+        Content::Option(Some(Box::new(Content::Unit)))
+    );
+}
+
+#[test]
+fn serialize_unit_struct() {
+    #[derive(Serialize)]
+    struct Foo;
+    assert_eq!(
+        to_content(Foo).unwrap(),
+        Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::Unit
+        }))
+    );
+}
+
+#[test]
+fn serialize_unit_variant() {
+    #[derive(Serialize)]
+    enum Foo {
+        Bar,
+    }
+    assert_eq!(
+        to_content(Foo::Bar).unwrap(),
+        Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 0,
+            variant: "Bar",
+            data: Data::Unit
+        }))
+    );
+}
+
+#[test]
+fn serialize_newtype_struct() {
+    #[derive(Serialize)]
+    struct Foo(bool);
+    assert_eq!(
+        to_content(Foo(true)).unwrap(),
+        Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::NewType {
+                value: Content::Bool(true)
+            }
+        }))
+    );
+}
+
+#[test]
+fn serialize_newtype_variant() {
+    #[derive(Serialize)]
+    enum Foo {
+        Bar(bool),
+    }
+    assert_eq!(
+        to_content(Foo::Bar(true)).unwrap(),
+        Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 0,
+            variant: "Bar",
+            data: Data::NewType {
+                value: Content::Bool(true)
+            }
+        }))
+    );
+}
+
+#[test]
+fn serialize_seq() {
+    assert_eq!(
+        to_content(Vec::<bool>::new()).unwrap(),
+        Content::Seq(Vec::new())
+    );
+    assert_eq!(
+        to_content(vec![true, false]).unwrap(),
+        Content::Seq(vec![Content::Bool(true), Content::Bool(false)])
+    );
+}
+
+#[test]
+fn serialize_tuple() {
+    assert_eq!(
+        to_content((true,)).unwrap(),
+        Content::Tuple(vec![Content::Bool(true)])
+    );
+    assert_eq!(
+        to_content((true, 'a', "foo")).unwrap(),
+        Content::Tuple(vec![
+            Content::Bool(true),
+            Content::Char('a'),
+            Content::String(Cow::Borrowed("foo"))
+        ])
+    );
+}
+
+#[test]
+fn serialize_tuple_struct() {
+    #[derive(Serialize)]
+    struct Foo(bool, char);
+    assert_eq!(
+        to_content(Foo(true, 'a')).unwrap(),
+        Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::Tuple {
+                values: vec![Content::Bool(true), Content::Char('a')],
+            }
+        }))
+    );
+}
+
+#[test]
+fn serialize_tuple_variant() {
+    #[derive(Serialize)]
+    enum Foo {
+        Bar(bool, char),
+    }
+    assert_eq!(
+        to_content(Foo::Bar(true, 'a')).unwrap(),
+        Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 0,
+            variant: "Bar",
+            data: Data::Tuple {
+                values: vec![Content::Bool(true), Content::Char('a')],
+            }
+        }))
+    );
+}
+
+#[test]
+fn serialize_map() {
+    assert_eq!(
+        to_content(BTreeMap::<(), ()>::new()).unwrap(),
+        Content::Map(Vec::new())
+    );
+    let mut map = BTreeMap::new();
+    map.insert('f', false);
+    map.insert('t', true);
+    assert_eq!(
+        to_content(map).unwrap(),
+        Content::Map(vec![
+            (Content::Char('f'), Content::Bool(false)),
+            (Content::Char('t'), Content::Bool(true)),
+        ])
+    );
+}
+
+#[test]
+fn serialize_struct() {
+    #[derive(Serialize)]
+    struct Foo {
+        bar: bool,
+        baz: char,
+    }
+    assert_eq!(
+        to_content(Foo {
+            bar: true,
+            baz: 'a'
+        })
+        .unwrap(),
+        Content::Struct(Box::new(Struct {
+            name: "Foo",
+            data: Data::Struct {
+                fields: vec![("bar", Content::Bool(true)), ("baz", Content::Char('a'))],
+            }
+        }))
+    );
+}
+
+#[test]
+fn serialize_struct_variant() {
+    #[derive(Serialize)]
+    #[allow(dead_code)]
+    enum Foo {
+        Bar { bar: bool, baz: char },
+        Baz { bar: bool, baz: char },
+    }
+    assert_eq!(
+        to_content(Foo::Baz {
+            bar: true,
+            baz: 'a',
+        })
+        .unwrap(),
+        Content::Enum(Box::new(Enum {
+            name: "Foo",
+            variant_index: 1,
+            variant: "Baz",
+            data: Data::Struct {
+                fields: vec![("bar", Content::Bool(true)), ("baz", Content::Char('a'))],
+            }
+        }))
+    );
+}

--- a/src/ser/tuple.rs
+++ b/src/ser/tuple.rs
@@ -1,0 +1,37 @@
+use crate::ser::Content;
+use crate::Error;
+use crate::Serializer;
+use alloc::vec::Vec;
+use serde::ser;
+
+pub struct Tuple {
+    vec: Vec<Content>,
+    human_readable: bool,
+}
+
+impl Tuple {
+    pub(super) const fn new(vec: Vec<Content>, human_readable: bool) -> Self {
+        Self {
+            vec,
+            human_readable,
+        }
+    }
+}
+
+impl ser::SerializeTuple for Tuple {
+    type Ok = Content;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let value = value.serialize(Serializer::new(self.human_readable))?;
+        self.vec.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Error> {
+        Ok(Content::Tuple(self.vec))
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,15 @@
+#![cfg(test)]
+
+use crate::Content;
+use crate::Error;
+use core::mem::size_of;
+
+#[test]
+fn content_size() {
+    assert!(size_of::<Content>() <= 32);
+}
+
+#[test]
+fn error_size() {
+    assert!(size_of::<Error>() <= 32);
+}

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,414 @@
+#![cfg(feature = "derive")]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+use serde::de::Visitor;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde_content::from_content;
+use serde_content::to_content;
+
+#[test]
+fn roundtrip_bool() {
+    let v = true;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = false;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_i8() {
+    let v = 0i8;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1i8;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_i16() {
+    let v = 0i16;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1i16;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_i32() {
+    let v = 0i32;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1i32;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_i64() {
+    let v = 0i64;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1i64;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_i128() {
+    let v = 0i128;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1i128;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_u8() {
+    let v = 0u8;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1u8;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_u16() {
+    let v = 0u16;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1u16;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_u32() {
+    let v = 0u32;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1u32;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_u64() {
+    let v = 0u64;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1u64;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_u128() {
+    let v = 0u128;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1u128;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_f32() {
+    let v = 0f32;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1f32;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_f64() {
+    let v = 0f64;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = 1f64;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_char() {
+    let v = 'a';
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_string() {
+    let v = "";
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content::<String>(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = "foo";
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content::<String>(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_bytes() {
+    #[derive(Debug, Clone, PartialEq)]
+    struct Bytes(Vec<u8>);
+    impl Serialize for Bytes {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            serializer.serialize_bytes(&self.0)
+        }
+    }
+    impl<'de> Deserialize<'de> for Bytes {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct BytesVisitor;
+            impl<'de> Visitor<'de> for BytesVisitor {
+                type Value = Bytes;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("bytes")
+                }
+
+                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(Bytes(v))
+                }
+            }
+
+            deserializer.deserialize_byte_buf(BytesVisitor)
+        }
+    }
+    let v = Bytes("".as_bytes().to_vec());
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = Bytes("foo".as_bytes().to_vec());
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_option() {
+    let v = None::<&str>;
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = Some("foo".to_owned());
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_unit() {
+    let v = ();
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = Some(());
+    let content = to_content(v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_unit_struct() {
+    #[derive(Serialize, Deserialize)]
+    struct Foo;
+    let content = to_content(Foo).unwrap();
+    from_content::<Foo>(content.clone()).unwrap();
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_unit_variant() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    enum Foo {
+        Bar,
+    }
+    let v = Foo::Bar;
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_newtype_struct() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Foo(bool);
+    let v = Foo(true);
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(dbg!(content.clone())).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_newtype_variant() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    enum Foo {
+        Bar(bool),
+    }
+    let v = Foo::Bar(true);
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_seq() {
+    let v = Vec::<bool>::new();
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content::<Vec<_>>(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = vec![true, false];
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content::<Vec<_>>(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_tuple() {
+    let v = (true,);
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let v = (true, 'a', "foo".to_owned());
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_tuple_struct() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Foo(bool, char);
+    let v = Foo(true, 'a');
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_tuple_variant() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    enum Foo {
+        Bar(bool, char),
+    }
+    let v = Foo::Bar(true, 'a');
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_map() {
+    let v = BTreeMap::<(), ()>::new();
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+    //
+    let mut v = BTreeMap::new();
+    v.insert('f', false);
+    v.insert('t', true);
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_struct() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Foo {
+        bar: bool,
+        baz: char,
+    }
+    let v = Foo {
+        bar: true,
+        baz: 'a',
+    };
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}
+
+#[test]
+fn roundtrip_struct_variant() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    enum Foo {
+        Bar { bar: bool, baz: char },
+    }
+    let v = Foo::Bar {
+        bar: true,
+        baz: 'a',
+    };
+    let content = to_content(&v).unwrap();
+    assert_eq!(v, from_content(content.clone()).unwrap());
+    assert_eq!(content.clone(), from_content(content).unwrap());
+}


### PR DESCRIPTION
`serde-content` is an alternative design for the private Serde content types [like this one](https://github.com/serde-rs/serde/blob/v1.0.11/serde/src/private/de.rs#L236-L265). These types are used to store the Rust values that represent the Serde data model. The model is stable and [well documented](https://serde.rs/data-model.html).

This crate offers a unified design for both serialising and deserialising data. The goal is to offer a stable interface with roundtrip guarantees when serialising to and deserialising from `Content` using `to_content` and `from_content`.