### PR TITLE
When deserializing a Map into an enum, allow for ignored extra keys

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "serde")]
 
+use std::ops::Deref;
 mod r#enum;
 mod identifier;
 mod map;
@@ -29,6 +30,8 @@ use map::Key;
 use serde::de::MapAccess;
 use serde::de::SeqAccess;
 use serde::de::Visitor;
+use serde::ser::Error as SerdeError;
+
 
 pub use error::Unexpected;
 
@@ -521,7 +524,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     fn deserialize_enum<V>(
         self,
         name: &'static str,
-        _variants: &'static [&'static str],
+        variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
@@ -542,8 +545,8 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
                 human_readable: self.human_readable,
                 coerce_numbers: self.coerce_numbers,
             }),
-            Value::Map(mut map) if map.len() == 1 => {
-                let (variant, data) = map.pop().unwrap();
+            Value::Map(map) => {
+                let (variant, data) = find_variant(variants, map)?;
                 visitor.visit_enum(r#enum::Access {
                     expected: name,
                     name: variant,
@@ -587,6 +590,28 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         self.human_readable
     }
 }
+fn find_variant<'a>(
+    variants: &'a [&'a str],
+    candidates: Vec<(Value<'a>, Value<'a>)>,
+) -> Result<(Value<'a>, Value<'a>), Error> {
+    let mut hit: Option<(Value<'a>, Value<'a>)> = None;
+    for item in candidates.iter() {
+        let (Value::String(key_str), _) = item else {
+            return Err(SerdeError::custom("Cannot deserialize map key into string"));
+        };
+
+        if variants.contains(&key_str.deref()) {
+            if hit.is_some() {
+                return Err(SerdeError::custom(
+                    "ambiguous enum, multiple variants present",
+                ));
+            }
+            hit = Some((item.0.clone(), item.1.clone()));
+        }
+    }
+    hit.ok_or_else(|| SerdeError::custom("Could not find enum variant in Map"))
+}
+
 
 impl<'de> de::Deserialize<'de> for Value<'static> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "serde")]
 
-use std::ops::Deref;
+use core::ops::Deref;
 mod r#enum;
 mod identifier;
 mod map;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,7 +32,6 @@ use serde::de::SeqAccess;
 use serde::de::Visitor;
 use serde::ser::Error as SerdeError;
 
-
 pub use error::Unexpected;
 
 /// A structure that deserializes Rust values into [Value].
@@ -611,7 +610,6 @@ fn find_variant<'a>(
     }
     hit.ok_or_else(|| SerdeError::custom("Could not find enum variant in Map"))
 }
-
 
 impl<'de> de::Deserialize<'de> for Value<'static> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -625,3 +625,53 @@ fn deserialize_struct_variant() {
         .unwrap()
     );
 }
+
+#[test]
+fn deserialize_enum_with_extra_data() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Foo {
+        Bar { bar: bool, baz: char },
+        Baz,
+    }
+
+    assert_eq!(
+        Ok(Foo::Bar {
+            bar: true,
+            baz: 'a',
+        }),
+        Deserializer::new(Value::Map(vec![
+            (
+                Value::String(Cow::Borrowed("Bar")),
+                Value::Map(vec![
+                    (Value::String(Cow::Borrowed("bar")), Value::Bool(true)),
+                    (Value::String(Cow::Borrowed("baz")), Value::Char('a'))
+                ]),
+            ),
+            (
+                Value::String(Cow::Borrowed("please_ignore")),
+                Value::Bool(false),
+            ),
+        ]))
+        .deserialize()
+    );
+    // if the keys for both variants exist in the map, we don't know which variant is right
+    assert!(Deserializer::new(Value::Map(vec![
+        (
+            Value::String(Cow::Borrowed("Bar")),
+            Value::Map(vec![
+                (Value::String(Cow::Borrowed("bar")), Value::Bool(true)),
+                (Value::String(Cow::Borrowed("baz")), Value::Char('a'))
+            ]),
+        ),
+        (Value::String(Cow::Borrowed("Baz")), Value::Bool(false),),
+    ]))
+    .deserialize::<Foo>()
+    .is_err());
+    // If none of the possible variants exists as a key, also fail
+    assert!(Deserializer::new(Value::Map(vec![(
+        Value::String(Cow::Borrowed("Unrelated")),
+        Value::Bool(false),
+    ),]))
+    .deserialize::<Foo>()
+    .is_err());
+}


### PR DESCRIPTION
When deserializing an enum the Deserializer currently expects a map with a single key corresponding to the variant of the enum. This breaks deserialization of query results in surrealdb, as an `id` key is injected into the map in the returned data.

This change modifies the enum deserialization logic to succeed if exactly one of all possible variants exists as a key in the map, regardless of any other data.
